### PR TITLE
Added missing `#` for RED[50]

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ const Color = {
     A700: '#0D6A1A',
   },
   RED: {
-    50: 'ffebee',
+    50: '#ffebee',
     100: '#ffcdd2',
     200: '#ef9a9a',
     300: '#e57373',


### PR DESCRIPTION
I ran into an error trying to use `RED[50]`, and then noticed it was missing a `#` in its value. Looks like that was the only one where it was missing.